### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This project is a Model Context Protocol (MCP) server implemented in TypeScript using the @modelcontextprotocol/sdk. It provides full CRUD tools for Requestly rules and groups, and can be run as a stdio MCP server.
 
+<a href="https://glama.ai/mcp/servers/@requestly/mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@requestly/mcp/badge" alt="Requestly Server MCP server" />
+</a>
+
 ## Features
 - Create, read, update, and delete Requestly rules
 - Create, read, update, and delete Requestly groups


### PR DESCRIPTION
This PR adds a badge for the [Requestly MCP Server](https://glama.ai/mcp/servers/@requestly/mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@requestly/mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@requestly/mcp/badge" alt="Requestly Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.