### PR TITLE
Add ScriptAttributeSchema

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@requestly/mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@requestly/mcp",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@requestly/mcp",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "build/index.js",
   "type": "module",
   "bin": {

--- a/src/__tests__/ruleSchemas.test.ts
+++ b/src/__tests__/ruleSchemas.test.ts
@@ -12,6 +12,7 @@ import {
   DelayPairSchema,
   ScriptPairSchema,
   ScriptModificationSchema,
+  ScriptAttributeSchema,
   RuleTypeEnum,
 } from '../types/ruleSchemas.js';
 import {
@@ -403,6 +404,42 @@ describe('ScriptModificationSchema', () => {
     const { codeType, ...rest } = validMod;
     expect(() => ScriptModificationSchema.parse(rest)).toThrow();
   });
+
+  it('accepts optional attributes array', () => {
+    const result = ScriptModificationSchema.parse({
+      ...validMod,
+      attributes: [
+        { name: 'data-tracker-id', value: '1234-5678' },
+        { name: 'type', value: 'text/javascript' },
+      ],
+    });
+    expect(result.attributes).toHaveLength(2);
+    expect(result.attributes![0].name).toBe('data-tracker-id');
+  });
+
+  it('accepts script without attributes (optional)', () => {
+    const result = ScriptModificationSchema.parse(validMod);
+    expect(result.attributes).toBeUndefined();
+  });
+
+  it('accepts empty attributes array', () => {
+    const result = ScriptModificationSchema.parse({ ...validMod, attributes: [] });
+    expect(result.attributes).toHaveLength(0);
+  });
+});
+
+describe('ScriptAttributeSchema', () => {
+  it('accepts valid attribute', () => {
+    expect(() => ScriptAttributeSchema.parse({ name: 'data-id', value: '123' })).not.toThrow();
+  });
+
+  it('rejects missing name', () => {
+    expect(() => ScriptAttributeSchema.parse({ value: '123' })).toThrow();
+  });
+
+  it('rejects missing value', () => {
+    expect(() => ScriptAttributeSchema.parse({ name: 'data-id' })).toThrow();
+  });
 });
 
 describe('ScriptPairSchema', () => {
@@ -424,7 +461,7 @@ describe('ScriptPairSchema', () => {
         scripts: [
           { codeType: 'js', value: 'alert("hi")', loadTime: 'beforePageLoad', type: 'code' },
           { codeType: 'css', value: 'body { color: red; }', loadTime: 'afterPageLoad', type: 'code' },
-          { codeType: 'js', value: 'https://cdn.example.com/lib.js', loadTime: 'beforePageLoad', type: 'url' },
+          { codeType: 'js', value: 'https://cdn.example.com/lib.js', loadTime: 'beforePageLoad', type: 'url', attributes: [{ name: 'defer', value: '' }] },
         ],
       })
     ).not.toThrow();
@@ -582,6 +619,27 @@ describe('createRuleSchema (discriminated union)', () => {
         }],
       })
     ).not.toThrow();
+  });
+
+  it('validates Script rule with custom attributes', () => {
+    const result = createRuleSchema.parse({
+      ...baseRule,
+      ruleType: 'Script',
+      pairs: [{
+        source: validSource,
+        scripts: [{
+          codeType: 'js',
+          value: 'https://tracker.example.com/script.js',
+          loadTime: 'afterPageLoad',
+          type: 'url',
+          attributes: [
+            { name: 'data-luigisbox-tracker-id', value: '1234-5678' },
+            { name: 'type', value: 'text/javascript' },
+          ],
+        }],
+      }],
+    });
+    expect(result.pairs[0].scripts[0].attributes).toHaveLength(2);
   });
 
   it('rejects Script rule with invalid pair (missing scripts)', () => {

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -125,6 +125,16 @@ describe('Create Rule Tool - Schema Validation per Rule Type', () => {
           source: validSource,
           scripts: [
             { codeType: 'js', value: 'console.log("injected")', loadTime: 'afterPageLoad', type: 'code' },
+            {
+              codeType: 'js',
+              value: 'https://tracker.example.com/script.js',
+              loadTime: 'afterPageLoad',
+              type: 'url',
+              attributes: [
+                { name: 'data-tracker-id', value: '12345' },
+                { name: 'type', value: 'text/javascript' },
+              ],
+            },
           ],
         }],
       },

--- a/src/types/ruleSchemas.ts
+++ b/src/types/ruleSchemas.ts
@@ -89,11 +89,17 @@ export const DelayPairSchema = z.object({
   }).describe('Delay value in milliseconds (stringified number).'),
 }).describe('Delay rule pair: source and delay.');
 
+export const ScriptAttributeSchema = z.object({
+  name: z.string().describe('Attribute name (e.g. "data-tracker-id", "type", "defer").'),
+  value: z.string().describe('Attribute value.'),
+}).describe('Custom HTML attribute to add to the injected script tag.');
+
 export const ScriptModificationSchema = z.object({
   codeType: z.enum(['js', 'css']).describe('Script language: js or css.'),
   value: z.string().describe('Script content or URL depending on type.'),
   loadTime: z.enum(['beforePageLoad', 'afterPageLoad']).describe('When to load the script: beforePageLoad or afterPageLoad.'),
   type: z.enum(['url', 'code']).describe('Script value type: url (external script URL) or code (inline script).'),
+  attributes: z.array(ScriptAttributeSchema).optional().describe('Optional array of custom HTML attributes to add to the injected script tag.'),
 }).describe('Script modification details.');
 
 export const ScriptPairSchema = z.object({


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for custom HTML attributes on injected script tags, allowing you to set properties like `data-*` attributes and script type specifications.

* **Chores**
  * Version bumped to 1.0.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->